### PR TITLE
Adding the ability to parse a object path to then build up a chain of le...

### DIFF
--- a/lens.js
+++ b/lens.js
@@ -17,6 +17,28 @@ function thisAndThen(b) {
     return b.compose(this);
 }
 
+// Not you could implement a bilby.js style of property.
+function isString(a) {
+    return typeof a === 'string';
+}
+function isNumber(a) {
+    return typeof a === 'number';
+}
+function isNotNaN(a) {
+    return !isNaN(a);
+}
+function isEmpty(a) {
+    return !/\S/.test(a);
+}
+function fold(a, v, f) {
+    var rec = function rec(v, index) {
+        return (index >= a.length) ?
+            v :
+            rec(f(v, a[index]), ++index);
+    };
+    return rec(v, 0);
+}
+
 // Methods
 Lens.id = function() {
     return Lens(function(target) {
@@ -76,6 +98,22 @@ Lens.arrayLens = function(index) {
                 return a[index];
             }
         );
+    });
+};
+Lens.parse = function(s) {
+    return fold(s.split('.'), Lens.id(), function(a, b) {
+        var access = fold(b.split('['), Lens.id(), function(a, b) {
+            var n = parseInt(b, 10);
+            return a.andThen(
+                (isNumber(n) && isNotNaN(n)) ?
+                Lens.arrayLens(n) :
+                   (isString(b) && isEmpty(b)) ?
+                   Lens.id() :
+                   Lens.objectLens(b)
+            );
+        });
+
+        return a.andThen(access);
     });
 };
 

--- a/test.js
+++ b/test.js
@@ -28,7 +28,20 @@ var Lens = require('./').Lens,
         {
             name: "Third record"
         }
-    ];
+    ],
+    complex = {
+        a: 1,
+        b: [1, 2, 3, 4],
+        c: {
+            x: [
+                {
+                    i: 1,
+                    j: "Hello"
+                }
+            ],
+            y: "World"
+        }
+    };
 
 exports.testUpdatePersonLocationNumber = function(test) {
     var location = Lens.objectLens('location'),
@@ -104,5 +117,26 @@ exports.testNestedFilter = function(test) {
             }
         ]
     );
+    test.done();
+};
+
+exports.testParserWithObjectAccess = function(test) {
+    var store = Lens.parse('c.y').run(complex);
+
+    test.equal(store.get(), 'World');
+    test.done();
+};
+
+exports.testParserWithObjectAndArrayAccess = function(test) {
+    var store = Lens.parse('c.x[0].j').run(complex);
+
+    test.equal(store.get(), 'Hello');
+    test.done();
+};
+
+exports.testParserWithEmptyValues = function(test) {
+    var store = Lens.parse('c...x[0].j').run(complex);
+
+    test.equal(store.get(), 'Hello');
     test.done();
 };


### PR DESCRIPTION
...nses.

This was just an idea of creating a series of lenses from a path, which I personally think is easier to use than the `lens.andThen(lens).andThen(lens)`.

Note: Empty items between the separators are classified as Lens.id items, not sure if this is a good thing or not. But you can then write `a..b..s....d[0]` which is the equivalent to `a.b.s.d[0]`.

Anyway I leave it in your safe hands to judge.
